### PR TITLE
Add careers page

### DIFF
--- a/careers/README.md
+++ b/careers/README.md
@@ -1,0 +1,12 @@
+# Reviewable Careers
+
+Do you have a passion for dev tooling, code review, or building software that helps your fellow engineers get the job done? Then you will fit right in with the team at Reviewable! We have been helping programmers around the world experience *GitHub code reviews done right* since 2014, and have been having lots of fun doing it. You can check out our job listings here:
+
+## Open Roles
+<hr/>
+
+<p align="center">Unfortunately, we do not have any open roles at this time...</p>
+
+<hr/>
+
+<sup>...but if you're feeling inspired, we do accept PRs against this repo! 😉</sup>


### PR DESCRIPTION
FYI mdbook doesn't let you render any pages from markdown that aren't in SUMMARY.md. So it has to be on the sidebar unless you know of a workaround...

I put the message about opening a PR in the repo at the bottom to make it slightly less obvious that this is an option. Sort of like a hidden opportunity for those with keen eyes. Figured you might have inputs on all of this so fire away!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reviewable/reviewable/951)
<!-- Reviewable:end -->
