### PR TITLE
Explictly instruct user to go to Build menu in Firebase instructions

### DIFF
--- a/enterprise/config.md
+++ b/enterprise/config.md
@@ -16,9 +16,9 @@ Set the application name, homepage URL, and application description to taste (bu
 
 Next, visit the [Firebase console](https://console.firebase.google.com/) and create a new project.  Set the name to taste (but preferably not just plain "Reviewable"), which will also determine your datastore's permanent name.  You don't need to enable Google Analytics.
 
-When your project is ready, select the _Realtime Database_ section and click _Create Database_.  You can select any region you want, and you can start with the security rules in locked mode.
+When your project is ready, go to _Build_ → _Realtime Database_ and click _Create Database_.  You can select any region you want, and you can start with the security rules in locked mode.
 
-When that's done, visit the _Authentication_ section and click _Get Started_.  Reviewable doesn't actually use Firebase Authentication so there's nothing more to do here (leave all the providers disabled), but this is the easiest way to have Firebase create a generic Web API Key for you.
+When that's done, go to _Build_ → _Authentication_ and click _Get Started_.  Reviewable doesn't actually use Firebase Authentication so there's nothing more to do here (leave all the providers disabled), but this is the easiest way to have Firebase create a generic Web API Key for you.
 
 Finally go to your Project Settings and prepare the following for configuring Reviewable:
 


### PR DESCRIPTION
It took me a minute to find the _Realtime Database_ and _Authentication_ sections in the Firebase console until I figured out that those are hidden inside the _Build_ menu. I hope the changes in this PR make things easier for future users and developers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/Reviewable/1003)
<!-- Reviewable:end -->
