### PR TITLE
Fix typo in settings.yaml example file

### DIFF
--- a/examples/settings/settings.yaml
+++ b/examples/settings/settings.yaml
@@ -16,7 +16,7 @@ badge:
   location: description-bottom
   # `when` optionally allows you to specify when to inject the Reviewable badge into the pull request.
   #  Valid options include: `accessed` (default), `published` and `requested`.
-  when: accesed
+  when: accessed
 
 # `default-review-style` allows you to choose how reviews are displayed.
 # Valid options include: `combined-commits` (default) and `one-per-commit`.


### PR DESCRIPTION
Looks like there was a small typo in the example file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/Reviewable/1197)
<!-- Reviewable:end -->
