### PR TITLE
Add playground link to example settings.yaml file

### DIFF
--- a/examples/settings/settings.yaml
+++ b/examples/settings/settings.yaml
@@ -71,7 +71,8 @@ coverage:
     Authorization: encrypted/rsa2:ObXundPmnmNRmJvPz20Y8+7egxnt5A3XjO5hSYxZGMNmFel2i5tNei8bZ/Uqd9WmcNNR37XodqyC7YR69h6PGQ==
 
 # `completion-file` gives the path to the custom review completion condition script, relative to the
-# settings file.  The script _must_ be in `/.reviewable` or a subdirectory.
+# settings file.  The script _must_ be in `/.reviewable` or a subdirectory.  You can test your script
+# in the Reviewable sandbox: https://reviewable.io/playground
 # https://docs.reviewable.io/repositories#completion-condition-script
 completion-file: completion.js
 


### PR DESCRIPTION
Add a link to the completion script playground into the example settings.yaml file. This covers a gap where a new user starts configuring repos using file-based settings instead of using the repository settings page and doesn't see other existing playground links.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/Reviewable/1281)
<!-- Reviewable:end -->
