### PR TITLE
Document Markdown completion descriptions

### DIFF
--- a/docs/admincenter.md
+++ b/docs/admincenter.md
@@ -663,6 +663,9 @@ A boolean indicating whether the review is complete or not.
 #### `description`
 A string describing the current status of the review, such as `2 of 5 files reviewed, 4 unresolved discussions`.
 
+#### `descriptionIsMarkdown`
+A boolean indicating that `description` should be rendered as Markdown in Reviewable's Checks panel.  The raw description will still be used for older clients and any plain text contexts, so consider also returning `shortDescription` if your Markdown description is long or contains formatting that would not read well in GitHub's status checks.
+
 #### `shortDescription`
 A string of no more than 50 characters describing the current status of the review, used for GitHub status checks.  If not provided, Reviewable will automatically truncate the `description` instead.
 


### PR DESCRIPTION
## Summary

Documents the new `descriptionIsMarkdown` custom completion condition output field.

## Changes

- Adds `descriptionIsMarkdown` to the condition output reference near `description` and `shortDescription`.
- Notes that older clients and plain text contexts still use the raw description.
- Recommends returning `shortDescription` when Markdown formatting would not read well in GitHub status checks.

## Impact

Repository admins configuring custom completion conditions can opt in to Markdown descriptions with the expected compatibility behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/Reviewable/1313)
<!-- Reviewable:end -->
