### PR TITLE
Document command browser selection

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -43,7 +43,7 @@ The steps for wiring an MCP server into your agent vary by tool, so have your to
 
 Before running the package, you'll need to:
 1. Install [Node.js](https://nodejs.org/) version 20 or higher.
-2. Install Chrome or Chromium.  It's probably already available on your personal computer, but if you need to set it up in CI you can use the command `npx playwright install --with-deps chromium`.
+2. Install Chrome or Chromium.  It's probably already available on your personal computer, but if you need to set it up in CI you can use the command `npx playwright install --with-deps chromium`.  If system Chrome is managed by enterprise policies that interfere with headless navigation, set `REVIEWABLE_COMMAND_BROWSER=chromium` to use Playwright-managed Chromium directly; `auto` (the default) and `chrome` are also supported.
 3. Set a `REVIEWABLE_URL` environment variable to `https://reviewable.io` or the URL of your local instance of Reviewable (e.g., `https://internal.reviewable.cloud`).
 4. Set a `REVIEWABLE_API_TOKEN` environment variable to your agent's secret token copied from the [agent identity](#creating-an-agent-identity) steps above.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -43,7 +43,7 @@ The steps for wiring an MCP server into your agent vary by tool, so have your to
 
 Before running the package, you'll need to:
 1. Install [Node.js](https://nodejs.org/) version 20 or higher.
-2. Install Chrome or Chromium.  It's probably already available on your personal computer, but if you need to set it up in CI you can use the command `npx playwright install --with-deps chromium`.  If system Chrome is managed by enterprise policies that interfere with headless navigation, set `REVIEWABLE_COMMAND_BROWSER=chromium` to use Playwright-managed Chromium directly; `auto` (the default) and `chrome` are also supported.
+2. Install Chrome or Chromium.  It's probably already available on your personal computer, but if you need to set it up in CI you can use the command `npx -y reviewable@latest install chromium`.  Run the installation command again after updating Reviewable so the Chromium revision stays aligned with Reviewable's installed Playwright dependency.  If system Chrome is managed by enterprise policies that interfere with headless navigation, set `REVIEWABLE_COMMAND_BROWSER=chromium` to use Playwright-managed Chromium directly; `auto` (the default) and `chrome` are also supported.
 3. Set a `REVIEWABLE_URL` environment variable to `https://reviewable.io` or the URL of your local instance of Reviewable (e.g., `https://internal.reviewable.cloud`).
 4. Set a `REVIEWABLE_API_TOKEN` environment variable to your agent's secret token copied from the [agent identity](#creating-an-agent-identity) steps above.
 


### PR DESCRIPTION
## Summary

- document `REVIEWABLE_COMMAND_BROWSER=chromium` in the agent setup instructions
- list the supported `auto`, `chrome`, and `chromium` values
- retain the existing Chromium installation command

## Why

Enterprise policies can allow system Chrome to launch but prevent its first headless navigation from completing. Users in managed environments need to know how to bypass system Chrome deterministically.

## Impact

Agent administrators can select Playwright-managed Chromium without changing Reviewable navigation timeouts or enabling concurrent browser startup.

## Related implementation

- [Reviewable/reviewable-command#28](https://github.com/Reviewable/reviewable-command/pull/28)

## Validation

- `git diff --check`
- command implementation: 176 tests passing, type-check and lint passing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/Reviewable/1325)
<!-- Reviewable:end -->
